### PR TITLE
anaconda-cloud rebuild for 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 0 # trigger
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0 # trigger
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,12 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
+  doc_url: https://anaconda.cloud/
+  dev_url: https://anaconda.cloud/
 
 extra:
   recipe-maintainers:
     - albertdefusco
     - mattkram
+  skip-lints:
+    - missing_pip_check


### PR DESCRIPTION
**Destination channel:** defaults

### Explanation of changes:

- Linter fixes
- Raise the build number since the meta.yaml has changed somewhat
